### PR TITLE
Fix missing React import in UnitContent

### DIFF
--- a/src/components/units/UnitContent.js
+++ b/src/components/units/UnitContent.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { CheckCircle, Lightbulb, BookOpen, ArrowRight, FileText, ExternalLink } from 'lucide-react';
 
 export default function UnitContent({ content, onComplete, isCompleted = false }) {


### PR DESCRIPTION
## Summary
- fix React.createRef usage by importing the React namespace

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6889c31908bc8333b3d0a8957490942e