### PR TITLE
Fix progress API to handle zero scores

### DIFF
--- a/src/pages/api/user/progress.js
+++ b/src/pages/api/user/progress.js
@@ -62,7 +62,7 @@ export default async function handler(req, res) {
 
       users[userIndex].progress[unitId] = {
         completed: completed || false,
-        score: score || null,
+        score: typeof score === 'number' ? score : null,
         timeSpent: timeSpent || 0,
         lastAccessed: new Date().toISOString(),
         ...(users[userIndex].progress[unitId] || {})


### PR DESCRIPTION
## Summary
- keep user's zero scores when saving progress

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6889cca8a0e08333a7afa790d165df8b